### PR TITLE
Setting the fetch size of the JDBC ResultSet to be the same as the R side

### DIFF
--- a/java-src/JDBCResultPull.java
+++ b/java-src/JDBCResultPull.java
@@ -65,6 +65,7 @@ public class JDBCResultPull {
      */
     public int fetch(int atMost) throws java.sql.SQLException {
 	setCapacity(atMost);
+    rs.setFetchSize(atMost);
 	count = 0;
 	while (rs.next()) {
 	    for (int i = 0; i < cols; i++)


### PR DESCRIPTION
Setting the fetch size on the ResultSet object increase performance by requesting a batch number of rows from the database instead of returning rows individually depending on what database you're using. Using RJDBC with Hiveserver2 saw huge performance increase by setting this value prior to iterating over the ResultSet.
