### PR TITLE
Ignore unsupported exception on setFetchSize

### DIFF
--- a/java-src/JDBCResultPull.java
+++ b/java-src/JDBCResultPull.java
@@ -65,7 +65,13 @@ public class JDBCResultPull {
      */
     public int fetch(int atMost) throws java.sql.SQLException {
 	setCapacity(atMost);
-    rs.setFetchSize(atMost);
+    // Some databases, e.g. Apache Phoenix don't support fetch size
+    try {
+        rs.setFetchSize(atMost);
+    }
+    catch (java.sql.SQLFeatureNotSupportedException e) {
+        // Do nothing
+    }
 	count = 0;
 	while (rs.next()) {
 	    for (int i = 0; i < cols; i++)


### PR DESCRIPTION
Some databases don't support setFetchSize, such as Apache Phoenix:
https://github.com/apache/phoenix/blob/master/phoenix-core/src/main/java/org/apache/phoenix/jdbc/PhoenixResultSet.java#L784

Older versions of RJDBC seemed to be compatible with Phoenix until 34b45a56163ebe700808349b11b9a36bcfb7b658
