### PR TITLE
getColumnName() -> getColumnLabel(); respect SQL "AS" aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+inst/java/RJDBC.jar

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RJDBC
-Version: 0.2-6
+Version: 0.2-7
 Title: Provides access to databases through the JDBC interface
 Author: Simon Urbanek <Simon.Urbanek@r-project.org>
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>

--- a/R/class.R
+++ b/R/class.R
@@ -298,7 +298,7 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
       cts[i] <- 1L
     } else
       l[[i]] <- character()
-    names(l)[i] <- .jcall(res@md, "S", "getColumnName", i)
+    names(l)[i] <- .jcall(res@md, "S", "getColumnLabel", i)
   }
   rp <- res@pull
   if (is.jnull(rp)) {
@@ -337,7 +337,7 @@ setMethod("dbColumnInfo", "JDBCResult", def = function(res, ...) {
   l <- list(field.name=character(), field.type=character(), data.type=character())
   if (cols < 1) return(as.data.frame(l))
   for (i in 1:cols) {
-    l$field.name[i] <- .jcall(res@md, "S", "getColumnName", i)
+    l$field.name[i] <- .jcall(res@md, "S", "getColumnLabel", i)
     l$field.type[i] <- .jcall(res@md, "S", "getColumnTypeName", i)
     ct <- .jcall(res@md, "I", "getColumnType", i)
     l$data.type[i] <- if (ct == -5 | ct ==-6 | (ct >= 2 & ct <= 8)) "numeric" else "character"


### PR DESCRIPTION
`getColumnName(...)` doesn't respect SQL aliases.
For a table `t` with column `x`, the query:

``` SQL
SELECT x AS foo FROM t
```

... would return the column as "x" rather than "foo".
When the returned value is a data frame in R, this causes lots of headaches, especially for queries where aliases are used specifically to create unique column names; else the returned data frame can have multiple columns of the same name, which is 'sneaky' behavior that some users of the package may not detect at first.

`getColumnLabel(...)` is the JDBC call that respects aliases if present. If no alias is used, it returns the formal column name in the underlying table/view.
