### PR TITLE
Improve dbDataType method for RJDBC connections

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -222,7 +222,7 @@ setMethod("dbDataType", signature(dbObj="JDBCConnection", obj = "ANY"),
           def = function(dbObj, obj, ...) {
             if (is.integer(obj)) "INTEGER"
             else if (is.numeric(obj)) "DOUBLE PRECISION"
-            else "VARCHAR(255)"
+            else paste0("VARCHAR(", max(nchar(as.character(obj))), ")")
           }, valueClass = "character")
 
 .sql.qescape <- function(s, identifier=FALSE, quote="\"") {


### PR DESCRIPTION
dbDataType used to return "VARCHAR(255)" for all text columns.
Updated so that it returns "VARCHAR(`n`)" for text columns, where `n` is the maximum value of `nchar()` for that column.

This used to be the default behaviour for DBI, and it seems like sensible default behaviour for RJDBC. 

See [this link](https://github.com/rstats-db/DBI/commit/028bcd56081c4366d2981926de066740868aae09) for a discussion around why it was changed to "TEXT" in DBI. I disagree with their logic, but you may find it more compelling.