### PR TITLE
loosen assumption that numeric columns can be cast to double

### DIFF
--- a/java/JDBCResultPull.java
+++ b/java/JDBCResultPull.java
@@ -77,8 +77,8 @@ public class JDBCResultPull {
 	while (rs.next()) {
 	    for (int i = 0; i < cols; i++)
 		if (cTypes[i] == CT_NUMERIC) {
-		    double val = rs.getDouble(i + 1);
-		    if (rs.wasNull()) val = NA_double;
+            Object o = rs.getObject(i + 1);
+            double val = (rs.wasNull() || o == null || !(o instanceof Number)) ? NA_double : ((Number) o).doubleValue();
 		    ((double[])data[i])[count] = val; 
 		} else
 		    ((String[])data[i])[count] = rs.getString(i + 1); 


### PR DESCRIPTION
Fix to allow non-Double types in numeric columns.  Currently having anything but double/Double in a numeric column results in a ClassCastException in fetch(...) method.  This fix only requires a subclass of Number for numeric columns.